### PR TITLE
Use yaml.safe_load() instead of yaml.load

### DIFF
--- a/cfg_load/__init__.py
+++ b/cfg_load/__init__.py
@@ -80,7 +80,7 @@ def load_yaml(yaml_filepath):
     config : dict
     """
     with open(yaml_filepath, 'r') as stream:
-        config = yaml.load(stream)
+        config = yaml.safe_load(stream)
     return config
 
 


### PR DESCRIPTION
yaml.load() is inherently unsafe and deprecated starting with PyYAML
5.1. See:
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

Note: I've never used cfg_load myself, just ran into a downstream project that emitted the deprecation warning. I can't judge if this breaks any use cases.